### PR TITLE
Add basic webhook support, refactor rest of library to accomadate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 
 There are already [plenty](https://www.npmjs.com/package/node-slack) [of](https://www.npmjs.com/package/slack-api) [JavaScript](https://www.npmjs.com/package/slack-client) [libraries](https://www.npmjs.com/package/slack-node) [out there](https://www.npmjs.com/package/slack-notify) written for the Slack API. Why build another one? And more importantly, why use this one?
 
-- **First-Class API Support:** Most Slack SDKs have either limited API support outside of webhooks, or no support at all. With Slackey, a good API experience is the focus.
+- **First-Class Web API Support:** Most Slack SDKs have either limited API support outside of webhooks, or no support at all. With Slackey, a good web API experience is the focus.
+- **Webhooks Support:** With version v1.0, "Incoming Webhooks" support is also available.
 - **Dependable:** Stability is another top priority for Slackey. Slackey is fully tested, and any issues and pull requests will be addressed quickly. Bug fixes will be prioritized whenever possible.
 - **Frontend & Backend Ready:** Slackey is committed to work in node, iojs, and even the browser (via [browserify](http://browserify.org/)).
 
 ```
-npm install slackey
+npm install --save slackey
 ```
 
 ## Usage
@@ -18,15 +19,15 @@ npm install slackey
 ### Initialize Slackey
 
 ```js
-var SlackAPI = require('slackey');
+var Slackey = require('slackey');
 
-var slackAPI = new SlackAPI({
-  // Required for getting access tokens
+var slackAPI = new Slackey({
+  // Required to call slackAPI.getAccessToken()
   clientID: 'XXX',
   clientSecret: 'XXX',
   // Optional
   apiURL:          // Defaults to: 'https://slack.com/api/'
-  authRedirectURI: // Defaults to: none
+  authRedirectURI: // (no default)
 });
 ```
 
@@ -48,25 +49,24 @@ slackAPI.getAccessToken({
 }
 ```
 
-### Get an API Client
+
+### Make Calls to the Web API
 
 ```js
-var slackAPIClient = slackAPI.getClient('USER_ACCESS_TOKEN');
+var slackAPIClient = slackAPI.getAPIClient('USER_ACCESS_TOKEN');
 ```
 
-### Make Calls to the API
-
-**`slackAPIClient.api(method, [arguments,] [callback(err, responseBody)])`**  - Call any Slack API method with an optional set of arguments. Authentication is automatically inherited from the client's authorized access token.
+**`slackAPIClient.send(method, [arguments,] [callback(err, responseBody)])`**  - Call any Slack API method with an optional set of arguments. Authentication is automatically inherited from the client's authorized access token.
 
 ```js
 // Get the list of users on your team
-slackAPIClient.api('users.list', function(err, response) {
+slackAPIClient.send('users.list', function(err, response) {
   console.log(err, response);
   // null {members: ...
 });
 
 // Post a message from your application
-slackAPIClient.api('chat.postMessage',
+slackAPIClient.send('chat.postMessage',
   {
     text: 'hello from nodejs! I am a robot, beep boop beep boop.',
     channel: '#channel'
@@ -80,16 +80,15 @@ slackAPIClient.api('chat.postMessage',
 
 *Note on `responseBody` object: Because the response body is only propagated when `ok: true` (see Errors section below) we remove that property from the response that we return. We do this because it is redundant, and so that all properties are related to the resource/response and not the status of that response.*
 
-
-### Errors
+#### Errors
 
 Any error object that occurs while making the request or recieving the response will be propagated to the callback.
 
-Any failed results from the Slack API (where `ok: false`) will propagate a custom `SlackError` error with the error message provided by Slack. Check for this type of error specifically to handle all possible, expected error case.
+Any failed results from the Slack API (where `ok: false`) will propagate a custom `SlackError` error object with the error message provided by Slack. Check for this type of error specifically to handle all possible, expected error cases.
 
 
 ```js
-slackAPIClient.api('channels.create', {name: 'mychannel'}, function(err, response) {
+slackAPIClient.send('channels.create', {name: 'mychannel'}, function(err, response) {
   if (err) {
     if (err.message === 'name_taken') {
       // Handle the case where the channel name already exists
@@ -104,3 +103,34 @@ slackAPIClient.api('channels.create', {name: 'mychannel'}, function(err, respons
   // Handle the successful response...
 );
 ```
+
+
+### Make Calls to an Incoming Webhook
+
+```js
+var slackWebhookClient = slackAPI.getWebhookClient('WEBHOOK_URL');
+```
+
+**`slackWebhookClient.send(payload, [callback(err)])`**  - Call a Slack webhook with a given set of arguments.
+
+```js
+slackWebhookClient.send({
+    text: 'hello from nodejs! I am a robot, beep boop beep boop.',
+    icon_emoji: ':ghost:'
+}, function(err) {
+  console.log(err); // null
+});
+```
+
+#### Errors
+
+Any error object that occurs while making the request or recieving the response will be propagated to the callback.
+
+Any failed results from the Slack API (where response body is not `ok`) will propagate a custom `SlackError` error object with the error message provided by Slack. Check for this type of error specifically to handle all possible, expected error cases.
+
+
+```js
+slackWebhookClient.send({"username": "monkey-bot"}, console.log)
+// { [SlackError: No text specified] name: 'SlackError', message: 'No text specified' }
+```
+

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
 
 var assert = require('assert');
 var SlackAPIClient = require('./lib/api-client');
+var SlackWebhookClient = require('./lib/webhook-client');
 var SlackError = require('./lib/slack-error');
 var makeAPIRequest = require('./lib/make-api-request');
 
@@ -37,18 +38,32 @@ var SlackAPI = module.exports = function SlackAPI(config) {
 SlackAPI.prototype.SlackError = SlackError;
 
 /**
- * Return a newly initialized client with the provided access token. You can use this client to interact
- * with the API on behalf of the user.
+ * Return a newly initialized API client with the provided access token. You can use this client to interact
+ * with any API method on behalf of the user.
  *
  * @param  {string} token
  * @return {SlackAPIClient}
  */
-SlackAPI.prototype.getClient = function(token) {
+SlackAPI.prototype.getAPIClient = function(token) {
   return new SlackAPIClient({
     token: token,
     apiURL: this.apiURL,
   });
 };
+
+/**
+ * Return a newly initialized Webhook client with the provided webhook URL. You can use this client to
+ * send requests to the Incoming Webhook provided.
+ *
+ * @param  {string} webhookURL
+ * @return {SlackWebhookClient}
+ */
+SlackAPI.prototype.getWebhookClient = function(webhookURL) {
+  return new SlackWebhookClient({
+    webhookURL: webhookURL,
+  });
+};
+
 
 /**
  * Call the 'oauth.access' API method to exchange a fresh auth code for an authorized API access token.

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -32,7 +32,7 @@ SlackAPIClient.prototype.SlackError = SlackError;
  * @param {Function} [callback] An optional callback to propagate the response to.
  * @callback {[Error, ResponseBody, Response]}
  */
-SlackAPIClient.prototype.api = function(method, options, callback) {
+SlackAPIClient.prototype.send = function(method, options, callback) {
   // If a callback was provided as the second argument, fix our args
   if (typeof options === 'function') {
     callback = options;

--- a/lib/make-api-request.js
+++ b/lib/make-api-request.js
@@ -13,9 +13,9 @@ var SlackError = require('./slack-error');
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Execute the request. An error is propagated if there was a problem making the
- * request or recieving the response. All completed responses, even those that
- * resulted in erroneus status codes, will be propagated to the consumer.
+ * Execute the API request. An error is propagated if there was a problem making the
+ * request or recieving the response. If `ok` is false, a special SlackError will be
+ * propagated to the callback with Slack's information about the error.
  *
  * Note that we call the user's callback with only response body, and not the full
  * object. With Slack's API, the body should be all you need to properly handle the
@@ -23,7 +23,7 @@ var SlackError = require('./slack-error');
  *
  * @param {Options} requestOptions
  * @param {Function} callback
- * @callback {[Error, ResponseBody, Response]}
+ * @callback {[Error, ResponseBody]}
  */
 module.exports = function makeAPIRequest(requestOptions, callback) {
   // Default to JSON always, unless explicitly told otherwise

--- a/lib/make-webhook-request.js
+++ b/lib/make-webhook-request.js
@@ -1,0 +1,36 @@
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+// Requirements
+////////////////////////////////////////////////////////////////////////////////
+
+var request = require('request');
+var SlackError = require('./slack-error');
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Public
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Execute the Webhook request. An error is propagated if there was a problem making
+ * the request or recieving the response. If the response body is not 'ok' a special
+ * SlackError will be propagated to the callback with information about the error.
+ *
+ * @param {Options} requestOptions
+ * @param {Function} callback
+ * @callback {[Error]}
+ */
+module.exports = function makeAPIRequest(requestOptions, callback) {
+  request(requestOptions, function(err, response) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    if (response.body !== 'ok') {
+      callback(new SlackError(response.body));
+      return;
+    }
+    callback(null);
+  });
+};

--- a/lib/webhook-client.js
+++ b/lib/webhook-client.js
@@ -1,0 +1,44 @@
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+// Requirements
+////////////////////////////////////////////////////////////////////////////////
+
+var querystring = require('querystring');
+var assert = require('assert');
+var SlackError = require('./slack-error');
+var makeWebhookRequest = require('./make-webhook-request');
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Public
+////////////////////////////////////////////////////////////////////////////////
+
+var SlackWebhookClient = module.exports = function SlackWebhookClient(options) {
+  assert(options && options.webhookURL, 'SlackWebhookClient constructor requires the `webhookURL` option');
+  this.webhookURL = options.webhookURL;
+};
+
+/** @type {SlackError} Attach the custom type to the SlackWebhookClient for consumer access */
+SlackWebhookClient.prototype.SlackError = SlackError;
+
+/**
+ * Call an Incoming Webhook following Slack's webhook calling conventions.
+ * See {@link https://api.slack.com/incoming-webhooks} for more information.
+ *
+ * @param {Object} payload The webhook payload, containing "text" and other arguments
+ * @param {Function} [callback] An optional callback to propagate any errors/success to
+ * @callback {[Error]} If an error occurs, it will be propagated to the client. If successful,
+ *  the callback will be called (no success arguments since no valuable info is returned).
+ */
+SlackWebhookClient.prototype.send = function(payload, callback) {
+  callback = callback || function () {/* no-op */};
+
+  var requestOptions = {
+    url: this.webhookURL,
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: querystring.stringify({payload: JSON.stringify(payload)}).toString('utf8')
+  };
+  makeWebhookRequest(requestOptions, callback);
+};

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,5 +1,9 @@
 {
   "env": {
     "mocha": true
+  },
+  "rules": {
+    // We use new to test side-effects
+    "no-new": 0
   }
 }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -3,10 +3,12 @@
 var assert = require('assert');
 var proxyquire = require('proxyquire');
 var SlackAPIClient = require('../lib/api-client');
+var SlackWebhookClient = require('../lib/webhook-client');
 var SlackError = require('../lib/slack-error');
 
 var SlackAPI;
 var SlackAPIClientSpy;
+var SlackWebhookClientSpy;
 var makeAPIRequestStub;
 
 describe('SlackAPI', function() {
@@ -14,8 +16,10 @@ describe('SlackAPI', function() {
   beforeEach(function() {
     makeAPIRequestStub = this.sinon.stub();
     SlackAPIClientSpy = this.sinon.spy(SlackAPIClient);
+    SlackWebhookClientSpy = this.sinon.spy(SlackWebhookClient);
     SlackAPI = proxyquire('../index.js', {
       './lib/api-client': SlackAPIClientSpy,
+      './lib/webhook-client': SlackWebhookClientSpy,
       './lib/make-api-request': makeAPIRequestStub
     });
   });
@@ -59,19 +63,36 @@ describe('SlackAPI', function() {
 
   });
 
-  describe('.getClient()', function() {
+  describe('.getAPIClient()', function() {
 
     it('should return a SlackAPIClient object when called', function() {
       var slackAPI = new SlackAPI();
-      var slackAPIClient = slackAPI.getClient('TOKEN');
+      var slackAPIClient = slackAPI.getAPIClient('TOKEN');
       assert.ok(slackAPIClient instanceof SlackAPIClient);
     });
 
     it('should pass the token and API URL to the SlackAPIClient constructor when called', function() {
       var slackAPI = new SlackAPI({apiURL: 'SLACK_API_URL'});
-      slackAPI.getClient('TOKEN');
+      slackAPI.getAPIClient('TOKEN');
       assert(SlackAPIClientSpy.calledWithNew());
       assert(SlackAPIClientSpy.calledWith({token: 'TOKEN', apiURL: 'SLACK_API_URL'}));
+    });
+
+  });
+
+  describe('.getWebhookClient()', function() {
+
+    it('should return a SlackWebhookClient object when called', function() {
+      var slackAPI = new SlackAPI();
+      var slackWebhookClient = slackAPI.getWebhookClient('WEBHOOK_URL');
+      assert.ok(slackWebhookClient instanceof SlackWebhookClient);
+    });
+
+    it('should pass the token and API URL to the SlackWebhookClient constructor when called', function() {
+      var slackAPI = new SlackAPI({apiURL: 'SLACK_API_URL'});
+      slackAPI.getWebhookClient('WEBHOOK_URL');
+      assert(SlackWebhookClientSpy.calledWithNew());
+      assert(SlackWebhookClientSpy.calledWith({webhookURL: 'WEBHOOK_URL'}));
     });
 
   });

--- a/tests/lib/api-client-test.js
+++ b/tests/lib/api-client-test.js
@@ -48,56 +48,56 @@ describe('SlackAPIClient', function() {
 
   });
 
-  describe('.api()', function() {
+  describe('.send()', function() {
 
     it('should create the URL from the apiURL property and the method argument when called', function() {
-      slackAPIClient.api('TEST_METHOD');
+      slackAPIClient.send('TEST_METHOD');
       assert(makeAPIRequestStub.called);
       assert(makeAPIRequestStub.calledWithMatch({url: 'YYYTEST_METHOD'}));
     });
 
     it('should still call the provided callback when no options argument is provided', function(done) {
       makeAPIRequestStub.yields();
-      slackAPIClient.api('TEST_METHOD', done);
+      slackAPIClient.send('TEST_METHOD', done);
     });
 
     it('should always set the correct default request arguments when called', function() {
-      slackAPIClient.api('TEST_METHOD');
+      slackAPIClient.send('TEST_METHOD');
       assert(makeAPIRequestStub.calledWithMatch({method: 'GET'}));
     });
 
     it('should append the token to the query string when called', function() {
-      slackAPIClient.api('TEST_METHOD');
+      slackAPIClient.send('TEST_METHOD');
       assert(makeAPIRequestStub.calledWithMatch({qs: {token: 'XXX'}}));
     });
 
     it('should pass the provided options as query params via GET when called on a normal method', function() {
       var methodOptions = {foo: 'bar'};
-      slackAPIClient.api('TEST_METHOD', methodOptions);
+      slackAPIClient.send('TEST_METHOD', methodOptions);
       assert(makeAPIRequestStub.calledWithMatch({qs: {foo: 'bar', token: 'XXX'}}));
     });
 
     it('should stringify the attachments argument when an array is provided to the "chat.postMessage" method', function() {
       var methodOptions = {attachments: [{text: 'foobar'}]};
-      slackAPIClient.api('chat.postMessage', methodOptions);
+      slackAPIClient.send('chat.postMessage', methodOptions);
       assert(makeAPIRequestStub.calledWithMatch({method: 'GET', qs: {attachments: '[{"text":"foobar"}]', token: 'XXX'}}));
     });
 
     it('should not modify the attachments argument when an string is provided to the "chat.postMessage" method', function() {
       var methodOptions = {attachments: '[{"text":"foobar"}]'};
-      slackAPIClient.api('chat.postMessage', methodOptions);
+      slackAPIClient.send('chat.postMessage', methodOptions);
       assert(makeAPIRequestStub.calledWithMatch({method: 'GET', qs: {attachments: '[{"text":"foobar"}]', token: 'XXX'}}));
     });
 
     it('should POST when called with "files.upload" method', function() {
-      slackAPIClient.api('files.upload');
+      slackAPIClient.send('files.upload');
       assert(makeAPIRequestStub.calledWithMatch({method: 'POST'}));
     });
 
     it('should attach the file option as form-upload data when called with "file.upload" method', function() {
       var fileData = new Buffer(123);
       var methodOptions = {file: fileData};
-      slackAPIClient.api('files.upload', methodOptions);
+      slackAPIClient.send('files.upload', methodOptions);
       assert(makeAPIRequestStub.calledWithMatch({formData: {file: fileData}}));
     });
 
@@ -105,7 +105,7 @@ describe('SlackAPIClient', function() {
     it('should attach the content option as form body data when called with "file.upload" method', function() {
       var contentData = 'TEST_UPLOAD_CONTENT';
       var methodOptions = {content: contentData};
-      slackAPIClient.api('files.upload', methodOptions);
+      slackAPIClient.send('files.upload', methodOptions);
       assert(makeAPIRequestStub.calledWithMatch({body: 'content=TEST_UPLOAD_CONTENT'}));
     });
 

--- a/tests/lib/make-webhook-request-test.js
+++ b/tests/lib/make-webhook-request-test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var assert = require('assert');
+var proxyquire = require('proxyquire');
+var SlackError = require('../../lib/slack-error');
+
+var makeWebhookRequest;
+var requestStub;
+
+describe('makeWebhookRequest', function() {
+
+  beforeEach(function() {
+    requestStub = this.sinon.stub();
+    makeWebhookRequest = proxyquire('../../lib/make-webhook-request', {
+      'request': requestStub
+    });
+  });
+
+  var requestOptions;
+
+  beforeEach(function() {
+    requestOptions = {foo: 'bar'};
+  });
+
+  it('should pass options argument to the request function when called', function() {
+    makeWebhookRequest(requestOptions);
+    assert(requestStub.called);
+    assert(requestStub.calledWith(requestOptions));
+  });
+
+  it('should return no success argument to the callback when the response is successfully returned', function(done) {
+    var responseBody = 'ok';
+    var responseObj = {response: true, body: responseBody};
+    requestStub.yields(null, responseObj);
+    makeWebhookRequest(requestOptions, function(err, response) {
+      assert.equal(err, null);
+      assert.equal(response, undefined);
+      done();
+    });
+  });
+
+  it('should propagate any request error to the callback when one occurs', function(done) {
+    var requestError = new Error('[TEST] request() error');
+    requestStub.yields(requestError);
+    makeWebhookRequest(requestOptions, function(err, response) {
+      assert.equal(err, requestError);
+      assert.equal(response, undefined);
+      done();
+    });
+  });
+
+  it('should propagate a SlackError object with the Slack response body message when the Slack response is bad', function(done) {
+    var responseBody = 'Payload was not valid JSON';
+    var responseObj = {response: true, body: responseBody};
+    requestStub.yields(null, responseObj);
+    makeWebhookRequest(requestOptions, function(err, response) {
+      assert(err instanceof SlackError);
+      assert.equal(err.message, responseBody);
+      done();
+    });
+  });
+
+});

--- a/tests/lib/webhook-client-test.js
+++ b/tests/lib/webhook-client-test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var assert = require('assert');
+var proxyquire = require('proxyquire');
+var SlackError = require('../../lib/slack-error');
+
+var SlackWebhookClient;
+var slackWebhookClient;
+var makeWebhookRequestStub;
+
+describe('SlackWebhookClient', function() {
+
+
+  beforeEach(function() {
+    makeWebhookRequestStub = this.sinon.stub();
+    SlackWebhookClient = proxyquire('../../lib/webhook-client.js', {
+      './make-webhook-request': makeWebhookRequestStub
+    });
+    slackWebhookClient = new SlackWebhookClient({
+      webhookURL: 'XXX',
+    });
+  });
+
+  describe('constructor', function() {
+
+    it('should throw an assertion error when called without options', function() {
+      assert.throws(function() {
+        new SlackWebhookClient();
+      });
+    });
+
+    it('should throw an assertion error when called without the webhookURL option', function() {
+      assert.throws(function() {
+        new SlackWebhookClient({foo: 'bar'});
+      });
+    });
+
+    it('should set the provided options when called with options', function() {
+      var createdSlackWebhookClient = new SlackWebhookClient({
+        webhookURL: 'XXX',
+      });
+      assert.ok(createdSlackWebhookClient instanceof SlackWebhookClient);
+      assert.equal(createdSlackWebhookClient.webhookURL, 'XXX');
+    });
+
+  });
+
+  describe('.SlackError', function() {
+
+    it('is the custom error type SlackError', function() {
+      assert.equal(slackWebhookClient.SlackError, SlackError);
+    });
+
+  });
+
+  describe('.send()', function() {
+
+    it('should create the URL from the webhookURL property when called', function() {
+      slackWebhookClient.send();
+      assert(makeWebhookRequestStub.called);
+      assert(makeWebhookRequestStub.calledWithMatch({url: 'XXX'}));
+    });
+
+    it('should always set the correct default request arguments when called', function() {
+      slackWebhookClient.send();
+      assert(makeWebhookRequestStub.calledWithMatch({
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+      }));
+    });
+
+    it('should send the payload as an url-encoded JSON string when called', function() {
+      var simplePayload = {text: 'Hello World!'};
+      slackWebhookClient.send(simplePayload);
+      assert(makeWebhookRequestStub.calledWithMatch({body: 'payload=%7B%22text%22%3A%22Hello%20World!%22%7D'}));
+    });
+
+    it('should send a complex payload as an url-encoded JSON string when called', function() {
+      var complexPayload = {
+        channel: '#general',
+        username: 'webhookbot',
+        text: 'This is posted to #general and comes from a bot named webhookbot.',
+        icon_emoji: ':ghost:'
+      };
+      slackWebhookClient.send(complexPayload);
+      assert(makeWebhookRequestStub.calledWithMatch({body: 'payload=%7B%22channel%22%3A%22%23general%22%2C%22username%22%3A%22webhookbot%22%2C%22text%22%3A%22This%20is%20posted%20to%20%23general%20and%20comes%20from%20a%20bot%20named%20webhookbot.%22%2C%22icon_emoji%22%3A%22%3Aghost%3A%22%7D'}));
+    });
+
+
+  });
+
+});


### PR DESCRIPTION
This new interface will most likely become the v1.0.0 release, since the rest of the library appears stable and has spent a few weeks being used in production at Worklife.

Resolves #4 "Webhooks Support"

- [NEW] getWebhookClient()
- apiClient.api() -> apiClient.send()
- getClient() -> getAPIClient()
- Updated in-code documentation
- Updated README