### PR TITLE
Refactor Slackey for added OAuth Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 There are already [plenty](https://www.npmjs.com/package/node-slack) [of](https://www.npmjs.com/package/slack-api) [JavaScript](https://www.npmjs.com/package/slack-client) [libraries](https://www.npmjs.com/package/slack-node) [out there](https://www.npmjs.com/package/slack-notify) written for the Slack API. Why build another one? And more importantly, why use this one?
 
 - **First-Class Web API Support:** Most Slack SDKs have either limited API support outside of webhooks, or no support at all. With Slackey, a good web API experience is the focus.
-- **Webhooks Support:** With version v1.0, "Incoming Webhooks" support is also available.
+- **Webhooks Support:** With the upcoming release of v1.0, support for [Slack's Incoming Webhooks](https://api.slack.com/incoming-webhooks) is also available.
 - **Dependable:** Stability is another top priority for Slackey. Slackey is fully tested, and any issues and pull requests will be addressed quickly. Bug fixes will be prioritized whenever possible.
 - **Frontend & Backend Ready:** Slackey is committed to work in node, iojs, and even the browser (via [browserify](http://browserify.org/)).
 
@@ -16,44 +16,15 @@ npm install --save slackey
 
 ## Usage
 
-### Initialize Slackey
-
 ```js
-var Slackey = require('slackey');
-
-var slackAPI = new Slackey({
-  // Required to call slackAPI.getAccessToken()
-  clientID: 'XXX',
-  clientSecret: 'XXX',
-  // Optional
-  apiURL:          // Defaults to: 'https://slack.com/api/'
-  authRedirectURI: // (no default)
-});
-```
-
-### Get an API Access Token
-
-**`slackAPI.getAccessToken(options, callback)`** - Exchange a valid OAuth authentication code for an API access token via the 'oauth.access' method.
-
-Supported options:
-- `code`: A valid, fresh OAuth auth code
-- `redirectURI`: (Optional) The redirect URI used to get the provided auth code, if one was provided. Defaults to the `authRedirectURI` value provided to the constructor.
-
-```js
-slackAPI.getAccessToken({
-  code: 'USER_AUTH_CODE',
-  redirectURI: 'http://localhost:5000/auth/slack/return',
-}, function(err, response) {
-  console.log(err, response);
-  // null {access_token: 'XXX', scope: 'read'}
-}
+var slackey = require('slackey');
 ```
 
 
 ### Make Calls to the Web API
 
 ```js
-var slackAPIClient = slackAPI.getAPIClient('USER_ACCESS_TOKEN');
+var slackAPIClient = slackey.getAPIClient('USER_ACCESS_TOKEN');
 ```
 
 **`slackAPIClient.send(method, [arguments,] [callback(err, responseBody)])`**  - Call any Slack API method with an optional set of arguments. Authentication is automatically inherited from the client's authorized access token.
@@ -105,10 +76,40 @@ slackAPIClient.send('channels.create', {name: 'mychannel'}, function(err, respon
 ```
 
 
+### Authorize New Users
+
+```js
+var slackOAuthClient = slackey.getOAuthClient({
+  // Required
+  clientID:
+  clientSecret:
+  // Optional
+  apiURL:          // Defaults to: 'https://slack.com/api/'
+  authRedirectURI: // (no default)
+});
+```
+
+**`slackOAuthClient.getToken(code, [options,] [callback])`** - Exchange a valid OAuth authentication code for an API access token via the 'oauth.access' Web API method.
+
+Supported options:
+- `redirectURI`: The redirect URI used to get the provided auth code, if one was provided. Defaults to the `authRedirectURI` value provided to the constructor.
+
+```js
+slackey.getAccessToken('USER_AUTH_CODE', {redirectURI: 'http://localhost:5000/slack'}, function(err, response) {
+  console.log(err, response);
+  // null {access_token: 'XXX', scope: 'read'}
+}
+```
+
+#### Errors
+
+See **Make Calls to the Web API** "Errors" Section above.
+
+
 ### Make Calls to an Incoming Webhook
 
 ```js
-var slackWebhookClient = slackAPI.getWebhookClient('WEBHOOK_URL');
+var slackWebhookClient = slackey.getWebhookClient('WEBHOOK_URL');
 ```
 
 **`slackWebhookClient.send(payload, [callback(err)])`**  - Call a Slack webhook with a given set of arguments.

--- a/index.js
+++ b/index.js
@@ -4,95 +4,67 @@
 // Requirements
 ////////////////////////////////////////////////////////////////////////////////
 
-var assert = require('assert');
-var SlackAPIClient = require('./lib/api-client');
-var SlackWebhookClient = require('./lib/webhook-client');
+var SlackAPIClient = require('./lib/clients/api-client');
+var SlackOAuthClient = require('./lib/clients/oauth-client');
+var SlackWebhookClient = require('./lib/clients/webhook-client');
 var SlackError = require('./lib/slack-error');
-var makeAPIRequest = require('./lib/make-api-request');
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// SlackAPI
+// Slackey
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * SlackAPI (aka Slackey) - A library for working with the Slack API. SlackAPI can
- * interact with the API directly, or on behalf of a user via a SlackAPIClient.
- *
- * @param {Object} config A collection of options to configure SlackAPI with.
- * @param {Object} [config.clientID] Your application's "client ID", required for working with auth codes
- * @param {Object} [config.clientSecret] Your application's "client Secret", required for working with auth codes
- * @param {Object} [config.authRedirectURI] The default redirect URL your application uses during OAuth authentication
- * @param {Object} [config.apiURL] The API URL to communicate with, defaults to 'https://slack.com/api/'
- * @return {void}
+ * Slackey - A library for working with the Slack API. Slackey can interact with the
+ * API via webhooks, or on behalf of a user via API & OAuth clients. See the `/clients`
+ * directory for more information about how each works.
  */
-var SlackAPI = module.exports = function SlackAPI(config) {
-  config = config || {};
-  this.clientID = config.clientID;
-  this.clientSecret = config.clientSecret;
-  this.apiURL = config.apiURL || 'https://slack.com/api/';
-  this.authRedirectURI = config.authRedirectURI;
-};
 
-/** @type {SlackError} Attach the custom type to the SlackAPI for consumer access */
-SlackAPI.prototype.SlackError = SlackError;
+module.exports = {
 
-/**
- * Return a newly initialized API client with the provided access token. You can use this client to interact
- * with any API method on behalf of the user.
- *
- * @param  {string} token
- * @return {SlackAPIClient}
- */
-SlackAPI.prototype.getAPIClient = function(token) {
-  return new SlackAPIClient({
-    token: token,
-    apiURL: this.apiURL,
-  });
-};
+  /** @type {SlackError} Attach the custom type to the SlackAPI for consumer access */
+  SlackError: SlackError,
 
-/**
- * Return a newly initialized Webhook client with the provided webhook URL. You can use this client to
- * send requests to the Incoming Webhook provided.
- *
- * @param  {string} webhookURL
- * @return {SlackWebhookClient}
- */
-SlackAPI.prototype.getWebhookClient = function(webhookURL) {
-  return new SlackWebhookClient({
-    webhookURL: webhookURL,
-  });
-};
+  /**
+   * Return a newly initialized OAuth API client with the provided credentials. You can
+   * use this client to interact with the OAuth authorization endpoints & token exchange
+   * for new users.
+   * See {@link https://api.slack.com/methods/oauth.access} for more information.
+   *
+   * @param  {Object} config  A configuration object for SlackOAuthClient, must include `clientID` & `clientSecret`
+   * @return {SlackAPIClient}
+   */
+  getOAuthClient: function getAPIClient(config) {
+    return new SlackOAuthClient(config);
+  },
 
-
-/**
- * Call the 'oauth.access' API method to exchange a fresh auth code for an authorized API access token.
- * You can use this token to generate a new SlackAPIClient via `.getClient()` and make calls on behalf
- * of the user.
- *
- * @param {Object} options
- * @param {string} options.code
- * @param {string} [options.redirectURI] This must match the originally submitted URI (if one was sent).
- *                                       Defaults to the 'authRedirectURI' option passed to the SlackAPI
- *                                       constructor, if one was provided.
- * @param {Function} callback
- * @throws {AssertionError} If clientID or clientSecret was not set on initialization.
- * @callback {[Error, ResponseBody, Response]}
- */
-SlackAPI.prototype.getAccessToken = function(options, callback) {
-  assert(this.clientID, 'a clientID is required to authorize users with the Slack API.');
-  assert(this.clientSecret, 'a clientSecret is required to authorize users with the Slack API.');
-  var redirectURI = options.redirectURI || this.authRedirectURI;
-  var requestOptions = {
-    url: this.apiURL + 'oauth.access',
-    method: 'POST',
-    form: {
-      client_id: this.clientID,
-      client_secret: this.clientSecret,
-      code: options.code,
-      redirect_uri: redirectURI,
+  /**
+   * Return a newly initialized API client with the provided access token. You can use
+   * this client to interact with any API method on behalf of the user.
+   * See {@link https://api.slack.com/web#basics} for more information.
+   *
+   * @param  {Object|string} config A configuration object for SlackAPIClient, or a single `token` value
+   * @return {SlackAPIClient}
+   */
+  getAPIClient: function getAPIClient(config) {
+    if (typeof config === 'string') {
+      config = {token: config};
     }
-  };
-  makeAPIRequest(requestOptions, callback);
-};
+    return new SlackAPIClient(config);
+  },
 
+  /**
+   * Return a newly initialized Webhook client with the provided webhook URL. You can use
+   * this client to send requests to a provided Incoming Webhook.
+   * See {@link https://api.slack.com/incoming-webhooks} for more information.
+   *
+   * @param  {string} webhookURL
+   * @return {SlackWebhookClient}
+   */
+  getWebhookClient: function getWebhookClient(webhookURL) {
+    return new SlackWebhookClient({
+      webhookURL: webhookURL
+    });
+  }
+
+};

--- a/lib/clients/api-client.js
+++ b/lib/clients/api-client.js
@@ -4,20 +4,33 @@
 // Requirements
 ////////////////////////////////////////////////////////////////////////////////
 
+var assert = require('assert');
 var querystring = require('querystring');
 var assign = require('object-assign');
-var SlackError = require('./slack-error');
-var makeAPIRequest = require('./make-api-request');
+var SlackError = require('../slack-error');
+var makeAPIRequest = require('../make-api-request');
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // Public
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * SlackAPIClient - A client for working with the Slack Web API endpoints. These endpoints
+ * require an authorized user's access token to work, so each SlackAPIClient instance requires
+ * one on creation to use on all future requests. A token can be recieved via SlackOAuthClient.
+ *
+ * @constructor
+ * @param {Object} options A collection of options to configure the client.
+ * @param {string} options.token An API Access Token to use for authorization of each call
+ * @param {string} [options.apiURL='https://slack.com/api/'] The base API URL to communicate with
+ * @return {void}
+ */
 var SlackAPIClient = module.exports = function SlackAPIClient(options) {
   options = options || {};
   this.token = options.token;
-  this.apiURL = options.apiURL;
+  this.apiURL = options.apiURL || 'https://slack.com/api/';
+  assert(this.token, 'a "token" option is required to make calls to the Slack API.');
 };
 
 /** @type {SlackError} Attach the custom type to the SlackAPIClient for consumer access */

--- a/lib/clients/oauth-client.js
+++ b/lib/clients/oauth-client.js
@@ -1,0 +1,75 @@
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+// Requirements
+////////////////////////////////////////////////////////////////////////////////
+
+var assert = require('assert');
+var SlackError = require('../slack-error');
+var makeAPIRequest = require('../make-api-request');
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Public
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * SlackOAuthClient - A client for working with the Slack OAuth authorization API endpoints.
+ *
+ * @constructor
+ * @param {Object} options A collection of options to configure the client.
+ * @param {string} options.clientID Your application's "client ID", required for working with auth codes
+ * @param {string} options.clientSecret Your application's "client Secret", required for working with auth codes
+ * @param {string} [options.authRedirectURI] The default redirect URL your application uses during OAuth authentication
+ * @param {string} [options.apiURL='https://slack.com/api/'] The base API URL to communicate with
+ * @return {void}
+ */
+var SlackOAuthClient = module.exports = function SlackOAuthClient(options) {
+  options = options || {};
+  this.clientID = options.clientID;
+  this.clientSecret = options.clientSecret;
+  this.authRedirectURI = options.authRedirectURI;
+  this.apiURL = options.apiURL || 'https://slack.com/api/';
+  assert(this.clientID, 'a "clientID" option is required to authorize users with the Slack API.');
+  assert(this.clientSecret, 'a "clientSecret" option is required to authorize users with the Slack API.');
+};
+
+/** @type {SlackError} Attach the custom type to the SlackOAuthClient for consumer access */
+SlackOAuthClient.prototype.SlackError = SlackError;
+
+/**
+ * Call the 'oauth.access' token endpoint with the client credentials & given options, and
+ * return a valid Slack API Access Token object. See {@link https://api.slack.com/methods/oauth.access}
+ * for more information.
+ *
+ * @param {string} code
+ * @param {Object} [options] An optional collection of authorization options
+ * @param {string} [options.redirectURI] The redirect URI that generated the original OAuth
+ *  code, defaults to the `authRedirectURI` option if one was provided on client creation.
+ * @param {Function} [callback] An optional callback to propagate the response to.
+ * @callback {[Error, ResponseBody]}
+ */
+SlackOAuthClient.prototype.getToken = function(oauthCode, options, callback) {
+
+  // If a callback was provided as the second argument, fix our args
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  } else {
+    options = options || {};
+    callback = callback || function () {/* no-op */};
+  }
+
+  var redirectURI = options.redirectURI || this.authRedirectURI;
+  var requestOptions = {
+    url: this.apiURL + 'oauth.access',
+    method: 'POST',
+    form: {
+      client_id: this.clientID,
+      client_secret: this.clientSecret,
+      code: oauthCode,
+      redirect_uri: redirectURI
+    }
+  };
+  makeAPIRequest(requestOptions, callback);
+};

--- a/lib/clients/oauth-client.js
+++ b/lib/clients/oauth-client.js
@@ -49,7 +49,7 @@ SlackOAuthClient.prototype.SlackError = SlackError;
  * @param {Function} [callback] An optional callback to propagate the response to.
  * @callback {[Error, ResponseBody]}
  */
-SlackOAuthClient.prototype.getToken = function(oauthCode, options, callback) {
+SlackOAuthClient.prototype.getToken = function(code, options, callback) {
 
   // If a callback was provided as the second argument, fix our args
   if (typeof options === 'function') {
@@ -67,7 +67,7 @@ SlackOAuthClient.prototype.getToken = function(oauthCode, options, callback) {
     form: {
       client_id: this.clientID,
       client_secret: this.clientSecret,
-      code: oauthCode,
+      code: code,
       redirect_uri: redirectURI
     }
   };

--- a/lib/clients/webhook-client.js
+++ b/lib/clients/webhook-client.js
@@ -6,14 +6,24 @@
 
 var querystring = require('querystring');
 var assert = require('assert');
-var SlackError = require('./slack-error');
-var makeWebhookRequest = require('./make-webhook-request');
+var SlackError = require('../slack-error');
+var makeWebhookRequest = require('../make-webhook-request');
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // Public
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * SlackWebhookClient - A client for working with a Slack Incoming Webhook URL. Each client is
+ * created to work with a single webhook. These URLs require no authorization to send messages,
+ * other than the URL itself.
+ *
+ * @constructor
+ * @param {Object} options A collection of options to configure the client.
+ * @param {string} options.webhookURL An Incoming Webhook URL to send messages to
+ * @return {void}
+ */
 var SlackWebhookClient = module.exports = function SlackWebhookClient(options) {
   assert(options && options.webhookURL, 'SlackWebhookClient constructor requires the `webhookURL` option');
   this.webhookURL = options.webhookURL;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Dependable JavaScript SDK for the Slack API",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha --reporter dot ./tests/util/setup.js ./tests/*"
+    "test": "node_modules/.bin/mocha --reporter dot --recursive ./tests/util/setup.js ./tests"
   },
   "keywords": [
     "slack",

--- a/tests/lib/clients/api-client-test.js
+++ b/tests/lib/clients/api-client-test.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert');
 var proxyquire = require('proxyquire');
-var SlackError = require('../../lib/slack-error');
+var SlackError = require('../../../lib/slack-error');
 
 var SlackAPIClient;
 var slackAPIClient;
@@ -13,29 +13,35 @@ describe('SlackAPIClient', function() {
 
   beforeEach(function() {
     makeAPIRequestStub = this.sinon.stub();
-    SlackAPIClient = proxyquire('../../lib/api-client.js', {
-      './make-api-request': makeAPIRequestStub
+    SlackAPIClient = proxyquire('../../../lib/clients/api-client.js', {
+      '../make-api-request': makeAPIRequestStub
     });
     slackAPIClient = new SlackAPIClient({
       token: 'XXX',
-      apiURL: 'YYY',
+      apiURL: 'YYY'
     });
   });
 
   describe('constructor', function() {
 
     it('should return a SlackAPIClient object when called', function() {
-      var createdSlackAPIClient = new SlackAPIClient();
-      assert.ok(createdSlackAPIClient instanceof SlackAPIClient);
+      assert.ok(slackAPIClient instanceof SlackAPIClient);
     });
 
     it('should set the provided options when called with options', function() {
       var createdSlackAPIClient = new SlackAPIClient({
         token: 'XXX',
-        apiURL: 'YYY',
+        apiURL: 'YYY'
       });
       assert.equal(createdSlackAPIClient.token, 'XXX');
       assert.equal(createdSlackAPIClient.apiURL, 'YYY');
+    });
+
+    it('should default the API URL to "https://slack.com/api/" when called without the apiURL option', function() {
+      var createdSlackAPIClient = new SlackAPIClient({
+        token: 'XXX'
+      });
+      assert.equal(createdSlackAPIClient.apiURL, 'https://slack.com/api/');
     });
 
   });
@@ -100,7 +106,6 @@ describe('SlackAPIClient', function() {
       slackAPIClient.send('files.upload', methodOptions);
       assert(makeAPIRequestStub.calledWithMatch({formData: {file: fileData}}));
     });
-
 
     it('should attach the content option as form body data when called with "file.upload" method', function() {
       var contentData = 'TEST_UPLOAD_CONTENT';

--- a/tests/lib/clients/oauth-client-test.js
+++ b/tests/lib/clients/oauth-client-test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+var assert = require('assert');
+var proxyquire = require('proxyquire');
+var SlackError = require('../../../lib/slack-error');
+
+var SlackOAuthClient;
+var slackOAuthClient;
+var makeAPIRequestStub;
+
+describe('SlackOAuthClient', function() {
+
+
+  beforeEach(function() {
+    makeAPIRequestStub = this.sinon.stub();
+    SlackOAuthClient = proxyquire('../../../lib/clients/oauth-client.js', {
+      '../make-api-request': makeAPIRequestStub
+    });
+    slackOAuthClient = new SlackOAuthClient({
+      clientID: 'XXX',
+      clientSecret: 'YYY'
+    });
+  });
+
+  describe('constructor', function() {
+
+    it('should return a SlackOAuthClient object when called', function() {
+      assert.ok(slackOAuthClient instanceof SlackOAuthClient);
+    });
+
+    it('should set the correct options when called with options', function() {
+      var createdSlackOAuthClient = new SlackOAuthClient({
+        authRedirectURI: 'WWW',
+        clientID: 'XXX',
+        clientSecret: 'YYY',
+        apiURL: 'ZZZ'
+      });
+      assert.equal(createdSlackOAuthClient.authRedirectURI, 'WWW');
+      assert.equal(createdSlackOAuthClient.clientID, 'XXX');
+      assert.equal(createdSlackOAuthClient.clientSecret, 'YYY');
+      assert.equal(createdSlackOAuthClient.apiURL, 'ZZZ');
+    });
+
+    it('should throw an assertion error when called without a "clientID" option', function() {
+      assert.throws(function() {
+        new SlackOAuthClient({
+          clientSecret: 'YYY'
+        });
+      }, assert.AssertionError);
+    });
+
+    it('should throw an assertion error when called without a "clientSecret" option', function() {
+      assert.throws(function() {
+        new SlackOAuthClient({
+          clientID: 'XXX'
+        });
+      }, assert.AssertionError);
+    });
+
+    it('should default the API URL to "https://slack.com/api/" when called without the apiURL option', function() {
+      var createdSlackOAuthClient = new SlackOAuthClient({
+        authRedirectURI: 'WWW',
+        clientID: 'XXX',
+        clientSecret: 'YYY'
+      });
+      assert.equal(createdSlackOAuthClient.apiURL, 'https://slack.com/api/');
+    });
+
+  });
+
+  describe('.SlackError', function() {
+
+    it('is the custom error type SlackError', function() {
+      assert.equal(slackOAuthClient.SlackError, SlackError);
+    });
+
+  });
+
+  describe('.getToken()', function() {
+
+    it('should POST to the oauth.access method with the correct form fields when called', function(done) {
+      var createdSlackOAuthClient = new SlackOAuthClient({
+        authRedirectURI: 'WWW',
+        clientID: 'XXX',
+        clientSecret: 'YYY'
+      });
+      makeAPIRequestStub.yields();
+
+      createdSlackOAuthClient.getToken('AUTH_CODE', {redirectURI: 'REDIRECT_URL'}, function() {
+        assert(makeAPIRequestStub.calledOnce);
+        assert.deepEqual(makeAPIRequestStub.firstCall.args[0], {
+          url: 'https://slack.com/api/oauth.access',
+          method: 'POST',
+          form: {
+            redirect_uri: 'REDIRECT_URL',
+            client_id: 'XXX',
+            client_secret: 'YYY',
+            code: 'AUTH_CODE'
+          }
+        });
+        done();
+      });
+    });
+
+    it('should use the default authRedirectURI when redirectURI option is not provided', function(done) {
+      var createdSlackOAuthClient = new SlackOAuthClient({
+        authRedirectURI: 'WWW',
+        clientID: 'XXX',
+        clientSecret: 'YYY'
+      });
+      makeAPIRequestStub.yields();
+
+      createdSlackOAuthClient.getToken('AUTH_CODE', {}, function() {
+        assert(makeAPIRequestStub.calledOnce);
+        assert.deepEqual(makeAPIRequestStub.firstCall.args[0], {
+          url: 'https://slack.com/api/oauth.access',
+          method: 'POST',
+          form: {
+            redirect_uri: 'WWW',
+            client_id: 'XXX',
+            client_secret: 'YYY',
+            code: 'AUTH_CODE'
+          }
+        });
+        done();
+      });
+    });
+
+    it('should create the URL from the apiURL property and the method argument when called', function() {
+      var createdSlackOAuthClient = new SlackOAuthClient({
+        clientID: 'XXX',
+        clientSecret: 'YYY',
+        apiURL: 'ZZZ'
+      });
+      createdSlackOAuthClient.getToken('AUTH_CODE');
+      assert(makeAPIRequestStub.called);
+      assert(makeAPIRequestStub.calledWithMatch({url: 'ZZZoauth.access'}));
+    });
+
+    it('should still call the provided callback when no options argument is provided', function(done) {
+      makeAPIRequestStub.yields();
+      slackOAuthClient.getToken('TEST_METHOD', done);
+    });
+
+  });
+
+});

--- a/tests/lib/clients/webhook-client-test.js
+++ b/tests/lib/clients/webhook-client-test.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert');
 var proxyquire = require('proxyquire');
-var SlackError = require('../../lib/slack-error');
+var SlackError = require('../../../lib/slack-error');
 
 var SlackWebhookClient;
 var slackWebhookClient;
@@ -13,11 +13,11 @@ describe('SlackWebhookClient', function() {
 
   beforeEach(function() {
     makeWebhookRequestStub = this.sinon.stub();
-    SlackWebhookClient = proxyquire('../../lib/webhook-client.js', {
-      './make-webhook-request': makeWebhookRequestStub
+    SlackWebhookClient = proxyquire('../../../lib/clients/webhook-client.js', {
+      '../make-webhook-request': makeWebhookRequestStub
     });
     slackWebhookClient = new SlackWebhookClient({
-      webhookURL: 'XXX',
+      webhookURL: 'XXX'
     });
   });
 
@@ -37,7 +37,7 @@ describe('SlackWebhookClient', function() {
 
     it('should set the provided options when called with options', function() {
       var createdSlackWebhookClient = new SlackWebhookClient({
-        webhookURL: 'XXX',
+        webhookURL: 'XXX'
       });
       assert.ok(createdSlackWebhookClient instanceof SlackWebhookClient);
       assert.equal(createdSlackWebhookClient.webhookURL, 'XXX');


### PR DESCRIPTION
- [NEW] SlackOAuthClient & slackey.getOAuthClient()
- Slackey.getAccessToken() -> slackOAuthClient.getToken()
- Slackey is no longer a custom type constructor, now just a simple object

Part of our big refactoring in preparation for v1.0
Closes #11